### PR TITLE
`dvdrtools` does not work on Linuxbrew

### DIFF
--- a/mm.rb
+++ b/mm.rb
@@ -3,9 +3,10 @@ class Mm < Formula
   url "https://github.com/mediamicroservices/mm/archive/mm_v2.2.12.tar.gz"
   sha256 "3882e283cc140224d54f200e59fadbb688e06f5e92d456202c8666370c5126ef"
   head "https://github.com/mediamicroservices/mm.git"
+  revision 1
 
   depends_on "cowsay"
-  depends_on "dvdrtools"
+  depends_on "dvdrtools" if OS.mac?
   depends_on "dvdauthor"
   depends_on "exiftool"
   depends_on "sdl"

--- a/mm.rb
+++ b/mm.rb
@@ -101,7 +101,7 @@ class Mm < Formula
         </dict>
         <key>ProgramArguments</key>
         <array>
-            <string>#{bin}/dbbackup</string>
+          <string>#{bin}/dbbackup</string>
         </array>
         <key>WorkingDirectory</key>
         <string>#{HOMEBREW_PREFIX}</string>

--- a/mm.rb
+++ b/mm.rb
@@ -5,11 +5,12 @@ class Mm < Formula
   head "https://github.com/mediamicroservices/mm.git"
   revision 1
 
-  # cdrtools is a Linuxbrew replacement for dvdtools
-  depends_on "cdrtools" unless OS.mac?
   depends_on "cowsay"
-  # dvdtools is available only on Homebrew
-  depends_on "dvdrtools" if OS.mac?
+  if OS.mac?
+    depends_on "dvdrtools"
+  else
+    depends_on "cdrtools"
+  end
   depends_on "dvdauthor"
   depends_on "exiftool"
   depends_on "sdl"

--- a/mm.rb
+++ b/mm.rb
@@ -5,9 +5,10 @@ class Mm < Formula
   head "https://github.com/mediamicroservices/mm.git"
   revision 1
 
+  # cdrtools is a Linuxbrew replacement for dvdtools
+  depends_on "cdrtools" unless OS.mac?
   depends_on "cowsay"
-  # Note: Only `makedvd` uses `mkisofs` which is part of `dvdrtools`.
-  # TO DO: Is there a Linuxbrew source for `mkisofs`? Maybe in `cdrtools`?
+  # dvdtools is available only on Homebrew
   depends_on "dvdrtools" if OS.mac?
   depends_on "dvdauthor"
   depends_on "exiftool"

--- a/mm.rb
+++ b/mm.rb
@@ -6,6 +6,8 @@ class Mm < Formula
   revision 1
 
   depends_on "cowsay"
+  # Note: Only `makedvd` uses `mkisofs` which is part of `dvdrtools`.
+  # TO DO: Is there a Linuxbrew source for `mkisofs`? Maybe in `cdrtools`?
   depends_on "dvdrtools" if OS.mac?
   depends_on "dvdauthor"
   depends_on "exiftool"


### PR DESCRIPTION
See: https://github.com/amiaopensource/homebrew-amiaos/issues/31